### PR TITLE
fix: lower capella fork epoch to 1 and change CL capella calculation

### DIFF
--- a/package_io/input_parser.star
+++ b/package_io/input_parser.star
@@ -155,7 +155,7 @@ def default_network_params():
 		"seconds_per_slot":                      4,
 		"slots_per_epoch":                       20,
 		"genesis_delay":                         10,
-		"capella_fork_epoch":                    5,
+		"capella_fork_epoch":                    1,
 	}
 
 def default_participant():

--- a/src/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
+++ b/src/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
@@ -171,7 +171,6 @@ def new_cl_genesis_config_template_data(network_id, seconds_per_slot, unix_times
 		"PreregisteredValidatorKeysMnemonic": preregistered_validator_keys_mnemonic,
 		"DepositContractAddress": deposit_contract_address,
 		"GenesisDelay": genesis_delay,
-		# each capella epoch is around 2 seconds, we multiply it with 4 so that it happens after EL
-		# TODO rework this with Pari
-		"CapellaForkEpoch": capella_fork_epoch*4
+		# each capella epoch is around 2 seconds, we multiply it with 3 so that it happens around the time of EL
+		"CapellaForkEpoch": capella_fork_epoch*3
 	}

--- a/src/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
+++ b/src/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
@@ -171,5 +171,7 @@ def new_cl_genesis_config_template_data(network_id, seconds_per_slot, unix_times
 		"PreregisteredValidatorKeysMnemonic": preregistered_validator_keys_mnemonic,
 		"DepositContractAddress": deposit_contract_address,
 		"GenesisDelay": genesis_delay,
-		"CapellaForkEpoch": capella_fork_epoch
+		# each capella epoch is around 2 seconds, we multiply it with 4 so that it happens after EL
+		# TODO rework this with Pari
+		"CapellaForkEpoch": capella_fork_epoch*4
 	}


### PR DESCRIPTION
The CL client will hit capella at 3*capella_fork_epoch or 6 minutes~
The EL client will hit capella at `32*12*capella_fork_epoch+genesis_delay` or 6.5 minutes

I don't see any errors