### PR TITLE
fix: change suggested fee recipient to first address in eth.accounts

### DIFF
--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -29,7 +29,7 @@ BEACON_HTTP_PORT_NUM		= 4000
 BEACON_METRICS_PORT_NUM		= 5054
 
 #  ---------------------------------- Validator client -------------------------------------
-VALIDATING_REWARDS_ACCOUNT	= "0x0000000000000000000000000000000000000000"
+VALIDATING_REWARDS_ACCOUNT	= "0x878705ba3f8Bc32FCf7F4CAa1A35E72AF65CF766"
 
 VALIDATOR_HTTP_PORT_ID		= "http"
 VALIDATOR_METRICS_PORT_ID	= "metrics"
@@ -264,7 +264,7 @@ def get_validator_config(
 		"--beacon-nodes=" + beacon_client_http_url,
 		#"--enable-doppelganger-protection", // Disabled to not have to wait 2 epochs before validator can start
 		# burn address - If unset, the validator will scream in its logs
-		"--suggested-fee-recipient=0x0000000000000000000000000000000000000000",
+		"--suggested-fee-recipient="+VALIDATING_REWARDS_ACCOUNT,
 		# vvvvvvvvvvvvvvvvvvv PROMETHEUS CONFIG vvvvvvvvvvvvvvvvvvvvv
 		"--metrics",
 		"--metrics-address=0.0.0.0",


### PR DESCRIPTION
There was some discussion last week where we were worried about suggested fee recipient being 0x00000___ causing issues with MEV. This changes the suggested fee recipient to the first genesis address