### PR TITLE
refactor: Deterministic names for `prelaunch-data-generator` services

### DIFF
--- a/src/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
+++ b/src/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
@@ -69,6 +69,7 @@ def generate_cl_genesis_data(
 			CONFIG_DIRPATH_ON_GENERATOR: genesis_generation_config_artifact_name,
 			EL_GENESIS_DIRPATH_ON_GENERATOR: el_genesis_data.files_artifact_uuid,
 		},
+		"cl-genesis-data",
 	)
 
 	all_dirpaths_to_create_on_generator = [

--- a/src/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.star
+++ b/src/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.star
@@ -37,6 +37,7 @@ def generate_cl_validator_keystores(
 	service_name = prelaunch_data_generator_launcher.launch_prelaunch_data_generator(
 		plan,
 		{},
+		"cl-validator-keystore",
 	)
 
 	all_output_dirpaths = []

--- a/src/prelaunch_data_generator/el_genesis/el_genesis_data_generator.star
+++ b/src/prelaunch_data_generator/el_genesis/el_genesis_data_generator.star
@@ -62,6 +62,7 @@ def generate_el_genesis_data(
 		{
 			CONFIG_DIRPATH_ON_GENERATOR: genesis_generation_config_artifact_name,
 		},
+		"el-genesis-data"
 	)
 
 

--- a/src/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
+++ b/src/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
@@ -9,13 +9,13 @@ ENTRYPOINT_ARGS = [
 ]
 
 # Launches a prelaunch data generator IMAGE, for use in various of the genesis generation
-def launch_prelaunch_data_generator(plan, files_artifact_mountpoints):
+def launch_prelaunch_data_generator(plan, files_artifact_mountpoints, service_name_suffix):
 
 	config = get_config(files_artifact_mountpoints)
 
 	service_name = "{0}{1}".format(
 		SERVICE_NAME_PREFIX,
-		time.now().unix_nano,
+		service_name_suffix,
 	)
 
 	plan.add_service(service_name, config)


### PR DESCRIPTION
Before:
<img width="1053" alt="Screenshot 2023-07-26 at 11 04 47" src="https://github.com/kurtosis-tech/eth-network-package/assets/18011812/b73dfd4e-8489-487a-8330-c461f1dfbf3f">


After:
<img width="1085" alt="Screenshot 2023-07-26 at 11 00 47" src="https://github.com/kurtosis-tech/eth-network-package/assets/18011812/16141faf-605b-41f8-94b7-f8ca91575f2c">
