### PR TITLE
feat: Make 'args' optional

### DIFF
--- a/main.star
+++ b/main.star
@@ -4,7 +4,7 @@ input_parser = import_module("github.com/kurtosis-tech/eth-network-package/packa
 static_files = import_module("github.com/kurtosis-tech/eth-network-package/static_files/static_files.star")
 genesis_constants = import_module("github.com/kurtosis-tech/eth-network-package/src/prelaunch_data_generator/genesis_constants/genesis_constants.star")
 
-def run(plan, args):
+def run(plan, args = {}):
 	args_with_right_defaults = input_parser.parse_input(args)
 
 	num_participants = len(args_with_right_defaults.participants)


### PR DESCRIPTION
Makes the `main.star#run` args optional, to make this even easier to call