### PR TITLE
docs: add eth-network-package deprecation notice & redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## This package has been deprecated. Please use the Ethereum Package [here](https://github.com/kurtosis-tech/ethereum-package)
 
-As of Sept 2023, this Kurtosis package has been deprecated and is no longer maintained. Please use the latest Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package).
+As of Sept 2023, this Kurtosis package has been deprecated and is no longer maintained. Please use the latest Ethereum Package [here](https://github.com/kurtosis-tech/ethereum-package).
 
 Package owners who rely on this `eth-network-package` are strongly advised to migrate to using the latest Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package). Please reach out on the [Kurtosis Discord](https://discord.gg/jJFG7XBqcY) if you have questions. Thank you!
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# :warning: DEPRECATION NOTICE :warning:
+
+## This package has been deprecated. Please use the Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package)
+
+As of Sept 2023, this Kurtosis package has been deprecated and is no longer maintained. Please use the latest Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package).
+
+Package owners who rely on this `eth-network-package` are strongly advised to migrate to using the latest Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package). Please reach out on the [Kurtosis Discord](https://discord.gg/jJFG7XBqcY) if you have questions. Thank you!
+
+
+******************
+
 # Ethereum Network Package
 
 ![Run of the Ethereum Network Package](/run.gif)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :warning: DEPRECATION NOTICE :warning:
 
-## This package has been deprecated. Please use the Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package)
+## This package has been deprecated. Please use the Ethereum Package [here](https://github.com/kurtosis-tech/ethereum-package)
 
 As of Sept 2023, this Kurtosis package has been deprecated and is no longer maintained. Please use the latest Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 As of Sept 2023, this Kurtosis package has been deprecated and is no longer maintained. Please use the latest Ethereum Package [here](https://github.com/kurtosis-tech/ethereum-package).
 
-Package owners who rely on this `eth-network-package` are strongly advised to migrate to using the latest Ethereum Package [here](https://github.com/kurtosis-tech/eth2-package). Please reach out on the [Kurtosis Discord](https://discord.gg/jJFG7XBqcY) if you have questions. Thank you!
+Package owners who rely on this `eth-network-package` are strongly advised to migrate to using the latest Ethereum Package [here](https://github.com/kurtosis-tech/ethereum-package). Please reach out on the [Kurtosis Discord](https://discord.gg/jJFG7XBqcY) if you have questions. Thank you!
 
 
 ******************


### PR DESCRIPTION
Adds a deprecation notice in the README and redirects folks to the eth2-package (which will be renamed to Ethereum Package).